### PR TITLE
Fixes a bug where the scaleX and scaleY were calculated wrongly.

### DIFF
--- a/CoreMLTest/EyeGazeLogic.swift
+++ b/CoreMLTest/EyeGazeLogic.swift
@@ -152,8 +152,8 @@ class EyeGazeLogic: EyeGazeLogicProtocol{
     }
     
     func calculateFaceGrid(imageBound: CGRect, gridSize:CGFloat, faceBound:CGRect) -> MLMultiArray?{
-        let scaleX = imageBound.width / gridSize
-        let scaleY = imageBound.height / gridSize
+        let scaleX = gridSize / imageBound.width
+        let scaleY = gridSize / imageBound.height
         
         guard let faceGridArray = try? MLMultiArray(shape: [625,1, 1], dataType: .double) else{
             return nil
@@ -174,7 +174,7 @@ class EyeGazeLogic: EyeGazeLogicProtocol{
         yHi = min(gridSize, max(1, yHi))
         
         for index in 0..<(Int(gridSize*gridSize)){
-            let row = round( CGFloat(index) / gridSize)
+            let row = CGFloat(Int( CGFloat(index) / gridSize))
             let column = CGFloat(index%Int(gridSize))
             if(row <= xHi && row >= xLow && column <= yHi && column >= yLow){
                 faceGridArray[index] = 1


### PR DESCRIPTION
Also, instead of using round() I am now using Int() which is similar to floor() because we want to round to the lower limit.